### PR TITLE
Fix issue with `strategy` indenting

### DIFF
--- a/charts/simple-ssh-bastion/templates/deployment.yaml
+++ b/charts/simple-ssh-bastion/templates/deployment.yaml
@@ -9,7 +9,7 @@ spec:
   {{- if .Values.strategy }}
   strategy:
     {{- with .Values.strategy }}
-      {{- toYaml . | nindent 2 }}
+      {{- toYaml . | nindent 4 }}
     {{- end }}
   {{- end }}
   selector:


### PR DESCRIPTION
The default `strategy` causes issues with deploying, due to the `rollingUpdate` key being under-indented.

This commit fixes that by correctly indenting.